### PR TITLE
updated hugo options

### DIFF
--- a/PDBminer
+++ b/PDBminer
@@ -22,6 +22,7 @@ from sys import exit
 import requests
 from requests.exceptions import ConnectionError
 from datetime import datetime
+import json
 
 parser = argparse.ArgumentParser(prog = "PDBminer",
                                  usage = 'PDBminer [-h] help [-n] cores and then either [-i] input file, or [-g] hugo_name and [-u] uniprot id')
@@ -95,62 +96,57 @@ def check_APIs():
 
 def check_input_file(df):
 
-    df = df.fillna("N/A")
-
     problems = []
-    hugo_name_list = []
     
     for i in range(len(df)):    
         if type(df.uniprot[i]) != str:
             problems.append(f"there is a problem with the uniprot input on the line of {df.loc[i]['uniprot']}")
         
         if ('hugo_name' in df.columns) == False:
-            uniprot_url = f"https://www.uniprot.org/uniprot/{df.uniprot[i]}.txt"
-            response = requests.get(uniprot_url.format(df.uniprot[i]))
-            for line in response.text.split("\n"):
-                if line.startswith("GN   Name="):
-                    hugo_name_list.append(line.split(";")[0].split("=")[1].split(" ")[0])   
+            uniprot_url = f"https://www.uniprot.org/uniprot/{df.uniprot[i]}.json"
+            response = requests.get(uniprot_url)
+            uniprot_file_content = json.loads(response.text)
+            df.loc[i,"hugo_name"] = uniprot_file_content['genes'][0]['geneName']['value']
                     
         else:
             if df.hugo_name[i] == "N/A":
-                uniprot_url = f"https://www.uniprot.org/uniprot/{df.uniprot[i]}.txt"
-                response = requests.get(uniprot_url.format(df.uniprot[i]))
-                for line in response.text.split("\n"):
-                    if line.startswith("GN   Name="):
-                        df.hugo_name[i] = line.split(";")[0].split("=")[1].split(" ")[0]    
+                uniprot_url = f"https://www.uniprot.org/uniprot/{df.uniprot[i]}.json"
+                response = requests.get(uniprot_url)
+                uniprot_file_content = json.loads(response.text)
+                df.loc[i,"hugo_name"] = uniprot_file_content['genes'][0]['geneName']['value']
     
             if type(df.hugo_name[i]) != str:
-                problems.append(f"there is a problem with the input on the line of {df.loc[i]['uniprot']}")
+                problems.append(f"there is a problem with the hugo name input on the line of {df.loc[i]['uniprot']}")
                     
         if ('uniprot_isoform' in df.columns) == True:
-            try:
-                int(df.uniprot_isoform[i])
-            except ValueError:
-                problems.append(f"there is a problem with the isoform input on the line of {df.loc[i]['uniprot']}")
+            if df.uniprot_isoform[i] == "N/A":
+                df.loc[i,"uniprot_isoform"] = 1
+            else:
+                try:
+                    int(df.uniprot_isoform[i])
+                except ValueError:
+                    problems.append(f"there is a problem with the isoform input on the line of {df.loc[i]['uniprot']}")
         else:
-            uniprot_isoform = [1] * len(df) 
-            df['uniprot_isoform'] = uniprot_isoform
+            df.loc[i,"uniprot_isoform"] = 1
         
         if ('mutations' in df.columns) == True:
             if type(df.mutations[i]) != str:
                 problems.append(f"there is a problem with the mutation input on the line of {df.loc[i]['uniprot']}")
         else:
-            mutations = ['N/A'] * len(df)
-            df['mutations'] = mutations
+            df.loc[i,"mutations"] = "N/A"
             
         if ('cluster_id' in df.columns) == True:
-            if len(set(df.cluster_id)) == 1 and df.cluster_id[0] == "N/A":
-                df.cluster_id = 999
-            try:
-                int(df.cluster_id[i])
-            except ValueError:
-                problems.append(f"there is a problem with the cluster_id input on the line of {df.loc[i]['hugo_name']}") 
+            if df.cluster_id[i] == "N/A":
+                df.loc[i,"cluster_id"] = 999            
+            else:
+                try:
+                    int(df.cluster_id[i])
+                except ValueError:
+                    problems.append(f"there is a problem with the cluster_id input on the line of {df.loc[i]['uniprot']}") 
         else: 
-            cluster_id = [999] * len(df)
-            df['cluster_id'] = cluster_id
-    
-    if len(hugo_name_list) == len(df):
-        df.insert(0, 'hugo_name', hugo_name_list)    
+            df.loc[i,"cluster_id"] = 999
+            
+    df = df[['hugo_name', 'uniprot', 'uniprot_isoform', 'mutations', 'cluster_id']]
     
     return df, problems
 
@@ -178,13 +174,11 @@ with open (f"{path}/log.txt", "w") as f:
         uniprot_id = [args.uniprot_id]
         if args.hugo_name:
             hugo_name = [args.hugo_name]
-        else:
-            uniprot_url = f"https://www.uniprot.org/uniprot/{args.uniprot_id}.txt"
-            response = requests.get(uniprot_url.format(uniprot_id))
-            for line in response.text.split("\n"):
-                if line.startswith("GN   Name="):
-                    hugo_name = line.split(";")[0].split("=")[1].split(" ")[0]
-                    hugo_name = [hugo_name]        
+        else:  
+            uniprot_url = f"https://www.uniprot.org/uniprot/{args.uniprot_id}.json"
+            response = requests.get(uniprot_url)
+            uniprot_file_content = json.loads(response.text)
+            hugo_name =[uniprot_file_content['genes'][0]['geneName']['value']]
         
         df = pd.DataFrame({'hugo_name':hugo_name,'uniprot':uniprot_id})
         
@@ -229,4 +223,3 @@ with open (f"{path}/log.txt", "w") as f:
     f.write(f"time: {finished-start}\n")
     f.write(f"before snakemake: {snake-start}\n")
     f.write("PDBminer has finished.\n")
-

--- a/PDBminer
+++ b/PDBminer
@@ -98,25 +98,42 @@ def check_input_file(df):
     df = df.fillna("N/A")
 
     problems = []
+    hugo_name_list = []
     
-    for i in range(len(df)):
-        if type(df.hugo_name[i]) != str:
-            problems.append(f"there is a problem with the input on the line of {df.loc[i]['hugo_name']}")
+    for i in range(len(df)):    
         if type(df.uniprot[i]) != str:
-            problems.append(f"there is a problem with the uniprot input on the line of {df.loc[i]['hugo_name']}")
+            problems.append(f"there is a problem with the uniprot input on the line of {df.loc[i]['uniprot']}")
         
+        if ('hugo_name' in df.columns) == False:
+            uniprot_url = f"https://www.uniprot.org/uniprot/{df.uniprot[i]}.txt"
+            response = requests.get(uniprot_url.format(df.uniprot[i]))
+            for line in response.text.split("\n"):
+                if line.startswith("GN   Name="):
+                    hugo_name_list.append(line.split(";")[0].split("=")[1].split(" ")[0])   
+                    
+        else:
+            if df.hugo_name[i] == "N/A":
+                uniprot_url = f"https://www.uniprot.org/uniprot/{df.uniprot[i]}.txt"
+                response = requests.get(uniprot_url.format(df.uniprot[i]))
+                for line in response.text.split("\n"):
+                    if line.startswith("GN   Name="):
+                        df.hugo_name[i] = line.split(";")[0].split("=")[1].split(" ")[0]    
+    
+            if type(df.hugo_name[i]) != str:
+                problems.append(f"there is a problem with the input on the line of {df.loc[i]['uniprot']}")
+                    
         if ('uniprot_isoform' in df.columns) == True:
             try:
                 int(df.uniprot_isoform[i])
             except ValueError:
-                problems.append(f"there is a problem with the isoform input on the line of {df.loc[i]['hugo_name']}")
+                problems.append(f"there is a problem with the isoform input on the line of {df.loc[i]['uniprot']}")
         else:
             uniprot_isoform = [1] * len(df) 
             df['uniprot_isoform'] = uniprot_isoform
         
         if ('mutations' in df.columns) == True:
             if type(df.mutations[i]) != str:
-                problems.append(f"there is a problem with the mutation input on the line of {df.loc[i]['hugo_name']}")
+                problems.append(f"there is a problem with the mutation input on the line of {df.loc[i]['uniprot']}")
         else:
             mutations = ['N/A'] * len(df)
             df['mutations'] = mutations
@@ -131,6 +148,9 @@ def check_input_file(df):
         else: 
             cluster_id = [999] * len(df)
             df['cluster_id'] = cluster_id
+    
+    if len(hugo_name_list) == len(df):
+        df.insert(0, 'hugo_name', hugo_name_list)    
     
     return df, problems
 
@@ -154,21 +174,34 @@ with open (f"{path}/log.txt", "w") as f:
         else:
             f.write("input file is correctly formatted\n")
 
-    elif args.hugo_name and args.uniprot_id:
-        hugo_name = [args.hugo_name]
+    elif args.uniprot_id:
         uniprot_id = [args.uniprot_id]
+        if args.hugo_name:
+            hugo_name = [args.hugo_name]
+        else:
+            uniprot_url = f"https://www.uniprot.org/uniprot/{args.uniprot_id}.txt"
+            response = requests.get(uniprot_url.format(uniprot_id))
+            for line in response.text.split("\n"):
+                if line.startswith("GN   Name="):
+                    hugo_name = line.split(";")[0].split("=")[1].split(" ")[0]
+                    hugo_name = [hugo_name]        
+        
         df = pd.DataFrame({'hugo_name':hugo_name,'uniprot':uniprot_id})
+        
         if args.uniprot_isoform:
             isoform = [args.uniprot_isoform]
             df['uniprot_isoform'] = isoform
         else: df['uniprot_isoform'] = [1]
+        
         if args.mutations:
             mutations = [args.mutations]
             df['mutations'] = mutations
         else: df['mutations'] = ["N/A"]
+        
         if args.cluster_id:
             cluster = [args.cluster_id]
             df['cluster_id'] = cluster
+        
         else: df['cluster_id'] = [999]
         df.to_csv(f'{path}/input_file.csv')
         input_file = 'input_file.csv'

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ by running one or more of these. Notice that the -f flag is used in the do.sh fi
 
 ### Using an input file
 
-The input file should be in a comma-separated values file format, with one mandatory columns; "uniprot" 
+The input file should be in a comma-separated values file format, with one mandatory column; "uniprot" 
 containing the accession number of the uniprot entry of interest.
 Additionally the optional columns are "hugo_name", "uniprot_isoform", "mutations" and "cluster_id". 
 

--- a/README.md
+++ b/README.md
@@ -71,37 +71,52 @@ by running one or more of these. Notice that the -f flag is used in the do.sh fi
 
 ### Using an input file
 
-The input file should be in a comma-separated values file format, with two mandatory columns; "hugo_name", and "uniprot".
-Additionally the optional columns are "uniprot_isoform", "mutations" and "cluster_id". 
+The input file should be in a comma-separated values file format, with one mandatory columns; "uniprot" 
+containing the accession number of the uniprot entry of interest.
+Additionally the optional columns are "hugo_name", "uniprot_isoform", "mutations" and "cluster_id". 
 
-Example of input_file.csv:
+Example of input file as a table:
 
 ```
-hugo_name | uniprot | uniprot_isoform | mutations         | cluster_id
------------------------------------------------------------------------
-MAT1A     |  Q00266 |         1       | P30N;W300H        | 1
-SSTR3     |  P05543 |         1       | T11S;C191S;R330L  | 1
-SAMD4A    |  Q9UPU9 |         3       | L10R;I80A         | 1
-TP53      |  P04637 |         2       | P278L;R337C;L344P | 1
+hugo_name,uniprot,uniprot_isoform,mutations,cluster_id
+MAT1A,Q00266,1,P30N;W300H,1
+SSTR3,P05543,1,T11S;C191S;R330L,1
+SAMD4A,Q9UPU9,3,L10R;I80A,1
+TP53,P04637,2,P278L;R337C;L344P,1
         
 ```
+
+The minimal required content for the input file: 
+
+```
+uniprot
+Q00266
+P05543
+Q9UPU9
+P04637
+
+```
+
+
 The name of the input file should be specified in the command line: 
 
 ### Running the Program with an input file
 
 ```
-$ python PDBminer -i [input file name] -n [cores]
+$ python PDBminer -i [input file name] -n [cores] -f [snakefile]
 ```
 ### Using the command line directly
 
 When PDBminer is run on only a single protein it may sometimes be beneficial to run it directly in the 
 commandline. To do so, a input file does not need to be constructured and the content can be specified 
-with flags. Again is the hugo_name and uniprot options mandatory while the rest is optional. 
+with flags. Again, the uniprot option is mandatory while the rest is optional. 
 
 ```
 $ python PDBminer -g [hugo_name] -u [uniprot_id] -s [uniprot_isoform] -m [mutations] -c [cluster_id] -n [cores] -f [path to snakefile]
 
 $ python PDBminer -g SSTR3 -u P05543 -m "T11S;C191S;R330L" -n 1 -f program/snakefile
+
+$ python PDBminer -u P05543 -f program/snakefile
 ``` 
 
 NOTICE: when isoform is not specified 1 is assumed.


### PR DESCRIPTION
fix #57 

By making the hugo name optional, PDBminer retrieves the gene name from the uniprot website. This allows a simplified commandline use and a simplified input file use. 

example: 

Inputfile:
```
uniprot
Q00266
P05543
Q9UPU9
P04637
```

commandline: 
`python PDBminer -u P05543`
