### PR TITLE
Bug fix

### DIFF
--- a/PDBminer
+++ b/PDBminer
@@ -162,12 +162,15 @@ def retrieve_hugo_name(uniprot_accession_number):
     # If the response is successfull, hugo name is collected.
     if response.status_code == 200:
         uniprot_file_content = json.loads(response.text)
-        hugo_name = uniprot_file_content['genes'][0]['geneName']['value']
-    
+        if 'genes'in uniprot_file_content and 'geneName'in uniprot_file_content['genes'][0]:
+            hugo_name = uniprot_file_content['genes'][0]['geneName']['value']
+        else:
+            hugo_name = "NA"
+            logging.warning(f"Uniprot has records in this id, but no Hugo Name could be retrived with UniProt for {uniprot_accession_number}. Gene name assigned NA.")
     # Otherwise the field is left empty
     else: 
         hugo_name = "NA"
-        logging.warning(f"No Hugo Name could be retrived with UniProt for {uniprot_id}. Gene name assigned NA.")
+        logging.warning(f"No Uniprot record in this id, no Hugo Name could be retrived with UniProt for {uniprot_accession_number}. Gene name assigned NA.")
         
     return hugo_name
     


### PR DESCRIPTION

<img width="874" alt="bug_presence" src="https://github.com/ELELAB/PDBminer/assets/109094377/27099204-b529-49be-8541-7a91721298a8">
As for some Uniprot id, there is no suitable gene name, so when running line 163, it gets a 200 OK, but when running into  line 165, it gets no key 'geneName', so raises KeyError The very first uniprot id identified is A0A1D6EIG7, I tried getting json by my browser and read the website of this id, the problem consists. As far as I know, many other genes correspond this situation. 
It can be seen that, the 'geneName' key is in absence.
Similarly,  we also need to check the existence of the key 'gene' in the same line 165. Also, in line 170, the name 'uniprot_id' is not defined, it may be 'uniprot_accession_number' instead?