### PR TITLE
option to save PDBs

### DIFF
--- a/PDBminer
+++ b/PDBminer
@@ -1277,8 +1277,7 @@ def align(combined_structure, path, peptide_min_length):
                 combined_structure.at[i, 'mutations_in_pdb'] = alignment_info[3]
                 combined_structure.at[i, 'b_factor'] = alignment_info[4]
                 combined_structure.at[i, 'warnings'] = alignment_info[5]
-                combined_structure.at[i, 'r_free'] = alignment_info[6] 
-            
+                combined_structure.at[i, 'r_free'] = alignment_info[6]
             #drop missing values. 
             else:
                 combined_structure = combined_structure.drop([i])
@@ -1724,5 +1723,3 @@ if __name__ == '__main__':
     
     logging.info(f"total runtime: {finished-start}")
     logging.info("PDBminer has finished.")
-        
-

--- a/PDBminer
+++ b/PDBminer
@@ -89,6 +89,13 @@ parser.add_argument("-p", '--peptide_length',
                     default = 5,
                     help='The minimum length of a peptide to be aligned. It is recomended not to go below 5 due to the risk of false alignment of a very small peptide')
 
+parser.add_argument("-a", "--file_save",
+                    metavar = "File save strategy",
+                    type=str,
+                    default = "none",
+                    choices=["none", "retain"],
+                    help="the file save strategy of the run (mmcif file format), default is none, no files are saved. Alternative is 'retain', which keeps all downloded files")
+
 parser.add_argument('-v', '--verbose', 
                     action='store_true', 
                     help='Enable verbose output')
@@ -1139,7 +1146,7 @@ def import_mmcif(structure_identifier, self_chains, path):
     return chain_dfs, chain_names, r_free
 
 def align_alphafold(alphafold_id, mutations, path):
-    logging.debug("FUNCTION: align_alphafold(alphafold_id, mutations)")
+    logging.debug("FUNCTION: align_alphafold(alphafold_id, mutations, path)")
     """
     This function takes an alphafold ID and the mutational positions. 
     The aim is to find the high quality areas of the protein, and set these in 
@@ -1206,7 +1213,8 @@ def align_alphafold(alphafold_id, mutations, path):
     
     b_factor_dict = dict({"A": list(AF_df.b_factor)})
     
-    return coverage, AA_in_PDB, b_factor_dict, r_free
+    return coverage, AA_in_PDB, b_factor_dict, r_free 
+
 
 def align(combined_structure, path, peptide_min_length):
     logging.debug("FUNCTION: align(combined_structure, path, peptide_min_length)")
@@ -1262,7 +1270,7 @@ def align(combined_structure, path, peptide_min_length):
                                            combined_structure.complex_protein[i],
                                            combined_structure.complex_protein_details[i],
                                            peptide_min_length)
-
+            
             if alignment_info[0] != '':
                 combined_structure.at[i, 'chains'] = alignment_info[0]  
                 combined_structure.at[i, 'coverage'] = alignment_info[1] 
@@ -1271,7 +1279,7 @@ def align(combined_structure, path, peptide_min_length):
                 combined_structure.at[i, 'b_factor'] = alignment_info[4]
                 combined_structure.at[i, 'warnings'] = alignment_info[5]
                 combined_structure.at[i, 'r_free'] = alignment_info[6]
-        
+                
             #drop missing values. 
             else:
                 combined_structure = combined_structure.drop([i])
@@ -1619,7 +1627,7 @@ def cleanup_all(structural_df,input_dataframe, output_format):
 
 ################################
 
-def process_uniprot(uniprot_id, df, output_format, peptide_min_length):
+def process_uniprot(uniprot_id, df, output_format, peptide_min_length, file_save_strategy):
     uniprot_dir = f"results/{uniprot_id}"
     os.makedirs(uniprot_dir, exist_ok=True)
     
@@ -1636,12 +1644,13 @@ def process_uniprot(uniprot_id, df, output_format, peptide_min_length):
 
         if len(structural_df) != 0:
             cleanup_all(structural_df, uniprot_dataframe, output_format)
-            
-    if os.path.isdir(f"{uniprot_dir}/structures"): 
-        shutil.rmtree(f"{uniprot_dir}/structures")
+    
+    if file_save_strategy == "none":
+        if os.path.isdir(f"{uniprot_dir}/structures"): 
+            shutil.rmtree(f"{uniprot_dir}/structures")
+    
 
-
-def run_list(input_file, cores, output_format, peptide_min_length):
+def run_list(input_file, cores, output_format, peptide_min_length, file_save_strategy):
     df = pd.read_csv(input_file)
     uniprot_list = df['uniprot'].unique()
 
@@ -1649,7 +1658,7 @@ def run_list(input_file, cores, output_format, peptide_min_length):
 
     with Pool(processes=cores) as pool:
         #use starmap to add multiple arguments.
-        pool.starmap(process_uniprot, [(uniprot_id, df, output_format, peptide_min_length) for uniprot_id in uniprot_list])
+        pool.starmap(process_uniprot, [(uniprot_id, df, output_format, peptide_min_length, file_save_strategy) for uniprot_id in uniprot_list])
 
 
 if __name__ == '__main__':
@@ -1710,7 +1719,7 @@ if __name__ == '__main__':
         
     logging.info("Pipeline is starting")
     
-    run_list(input_file, args.cores, args.format, args.peptide_length)
+    run_list(input_file, args.cores, args.format, args.peptide_length, args.file_save)
     
     finished = datetime.now() 
     

--- a/PDBminer
+++ b/PDBminer
@@ -90,7 +90,7 @@ parser.add_argument("-p", '--peptide_length',
                     help='The minimum length of a peptide to be aligned. It is recomended not to go below 5 due to the risk of false alignment of a very small peptide')
 
 parser.add_argument("-a", "--file_save",
-                    metavar = "File save strategy",
+                    metavar = "file_save_strategy",
                     type=str,
                     default = "none",
                     choices=["none", "retain"],
@@ -1642,10 +1642,8 @@ def process_uniprot(uniprot_id, df, output_format, peptide_min_length, file_save
         if len(structural_df) != 0:
             cleanup_all(structural_df, uniprot_dataframe, output_format)
     
-    if file_save_strategy == "none":
-        if os.path.isdir(f"{uniprot_dir}/structures"): 
-            shutil.rmtree(f"{uniprot_dir}/structures")
-    
+    if file_save_strategy == "none" and os.path.isdir(f"{uniprot_dir}/structures"):
+        shutil.rmtree(f"{uniprot_dir}/structures")
 
 def run_list(input_file, cores, output_format, peptide_min_length, file_save_strategy):
     df = pd.read_csv(input_file)

--- a/PDBminer
+++ b/PDBminer
@@ -1215,7 +1215,6 @@ def align_alphafold(alphafold_id, mutations, path):
     
     return coverage, AA_in_PDB, b_factor_dict, r_free 
 
-
 def align(combined_structure, path, peptide_min_length):
     logging.debug("FUNCTION: align(combined_structure, path, peptide_min_length)")
     """
@@ -1269,7 +1268,7 @@ def align(combined_structure, path, peptide_min_length):
                                            combined_structure.uniprot_id[i],
                                            combined_structure.complex_protein[i],
                                            combined_structure.complex_protein_details[i],
-                                           peptide_min_length)
+                                           peptide_min_length) 
             
             if alignment_info[0] != '':
                 combined_structure.at[i, 'chains'] = alignment_info[0]  
@@ -1278,8 +1277,8 @@ def align(combined_structure, path, peptide_min_length):
                 combined_structure.at[i, 'mutations_in_pdb'] = alignment_info[3]
                 combined_structure.at[i, 'b_factor'] = alignment_info[4]
                 combined_structure.at[i, 'warnings'] = alignment_info[5]
-                combined_structure.at[i, 'r_free'] = alignment_info[6]
-                
+                combined_structure.at[i, 'r_free'] = alignment_info[6] 
+            
             #drop missing values. 
             else:
                 combined_structure = combined_structure.drop([i])
@@ -1726,3 +1725,4 @@ if __name__ == '__main__':
     logging.info(f"total runtime: {finished-start}")
     logging.info("PDBminer has finished.")
         
+

--- a/PDBminer
+++ b/PDBminer
@@ -1213,7 +1213,7 @@ def align_alphafold(alphafold_id, mutations, path):
     
     b_factor_dict = dict({"A": list(AF_df.b_factor)})
     
-    return coverage, AA_in_PDB, b_factor_dict, r_free 
+    return coverage, AA_in_PDB, b_factor_dict, r_free
 
 def align(combined_structure, path, peptide_min_length):
     logging.debug("FUNCTION: align(combined_structure, path, peptide_min_length)")
@@ -1268,8 +1268,7 @@ def align(combined_structure, path, peptide_min_length):
                                            combined_structure.uniprot_id[i],
                                            combined_structure.complex_protein[i],
                                            combined_structure.complex_protein_details[i],
-                                           peptide_min_length) 
-            
+                                           peptide_min_length)            
             if alignment_info[0] != '':
                 combined_structure.at[i, 'chains'] = alignment_info[0]  
                 combined_structure.at[i, 'coverage'] = alignment_info[1] 


### PR DESCRIPTION
this PR fixes #72 where the user will be able to add the flag "--file_save retain" if they wish to retain the downloaded mmcif files. The default is none. 

Further enhancement of this feature is a potential implementation of "--file_save renumber" to renumber the chains of relevance, a possibility is to use the CifFile librarys ReadCif, where we can overwrite the sequence number in the file. Yet testing have shown a few challenges why this could be implemented first, and the user can renumber as needed with for example pdb-tools. 