### PR TITLE
Now we don't exit if there is no structure present

### DIFF
--- a/PDBminer/PDBminer.py
+++ b/PDBminer/PDBminer.py
@@ -541,7 +541,6 @@ def get_structure_df(uniprot_id):
 
     if structure_df.empty:
         logging.error(f"No structures found for UniProt ID {uniprot_id}. Skipping.")
-        return structure_df
     
     try:
         structure_df[['PDBREDOdb', 'PDBREDOdb_details']] = structure_df['PDBREDOdb'].apply(pd.Series)


### PR DESCRIPTION
fix #84  When we were using as input a gene that has no structure at all it was crashing. Now it will just rise a warning and it will not crash